### PR TITLE
make applet work again after camelCase refactoring

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -30,7 +30,7 @@ MyApplet.prototype = {
         // as the width of the displayed data changes.
         this.actor.width = 100; // heuristically determined value
         // Make label less prominent.
-        this._applet_label.set_style("font-weight: normal;");
+        (this._applet_label || this._appletLabel).set_style("font-weight: normal;");
         
         this._orientation = orientation;
         this.cinnamonMem = new CinnamonMemMonitor();


### PR DESCRIPTION
Hey!

After dalcde's camelCase refactoring Cinnamonitor won't load, due to an access of a renamed variable. I've added an arguably ugly fix that will work both with the old ugly codebase and the new beautiful one.

Regards, autarkper
